### PR TITLE
Update include paths to use local Lua sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore compiled binaries and temporary build artifacts
+bin/

--- a/LuaTable.ino
+++ b/LuaTable.ino
@@ -1,8 +1,8 @@
 #include <Arduino.h>
 extern "C" {
-#include <lua.h>
-#include <lauxlib.h>
-#include <lualib.h>
+#include "lua-5.4.8/src/lua.h"
+#include "lua-5.4.8/src/lauxlib.h"
+#include "lua-5.4.8/src/lualib.h"
 }
 
 // Lua interpreter state


### PR DESCRIPTION
## Summary
- update Lua include paths to point at `lua-5.4.8/src`
- add `.gitignore` to ignore the local `bin/` folder

## Testing
- `./bin/arduino-cli compile --fqbn arduino:avr:uno .` *(fails: platform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68798ecd1c988330a8322ec9b1662468